### PR TITLE
Create a new VNet from the Portal UI

### DIFF
--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -393,6 +393,15 @@
                 },
                 "elements": [
                     {
+                        "name": "warning",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "If you are on a Pay As You Go Azure Subscription you cannot use the Free Log Analytics tier."
+                        },
+                        "visible": true
+                    },
+                    {
                         "name": "tier",
                         "type": "Microsoft.Common.DropDown",
                         "label": "Tier",

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -30,8 +30,8 @@
                         "name": "warning",
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
-                            "icon": "Warning",
-                            "text": "The network will be created in the same resource group as the Managed Application. The resource group setting here will be ignored."
+                            "icon": "Info",
+                            "text": "If you choose to create a new network here, it will be part of the Managed Application resource group, thus you will not be able to manage it yourself."
                         },
                         "visible": true
                     },

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -27,6 +27,15 @@
                 },
                 "elements": [
                     {
+                        "name": "warning",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Warning",
+                            "text": "The network will be created in the same resource group as the Managed Application. The resource group setting here will be ignored."
+                        },
+                        "visible": true
+                    },
+                    {
                         "name": "virtualNetwork",
                         "type": "Microsoft.Network.VirtualNetworkCombo",
                         "label": {
@@ -114,8 +123,8 @@
                     {
                         "name": "orgname",
                         "type": "Microsoft.Common.TextBox",
-                        "label": "Organisation Name",
-                        "toolTip": "Name of the organisation to create",
+                        "label": "Organization Name",
+                        "toolTip": "Name of the organization to create",
                         "constraints": {
                             "required": true,
                             "regex": "^[a-z0-9]+$",
@@ -126,7 +135,7 @@
                     {
                         "name": "orgdescription",
                         "type": "Microsoft.Common.TextBox",
-                        "label": "Organisation Description",
+                        "label": "Organization Description",
                         "toolTip": "A description of the organization, perhaps the epanded version of the name for example",
                         "constraints": {
                             "required": true,
@@ -471,6 +480,7 @@
             "prefix": "[basics('prefix')]",
             "virtualNetworkName": "[steps('customerNetworkStep').virtualNetwork.name]",
             "customerResourceGroupName": "[steps('customerNetworkStep').virtualNetwork.resourceGroup]",
+            "existingVNetFromUI": "[steps('customerNetworkStep').virtualNetwork.newOrExisting]",
             "subnetName": "[steps('customerNetworkStep').virtualNetwork.subnets.customer.name]",
             "chefUsername": "[steps('chefCredentialsStep').username]",
             "chefUserFullname": "[steps('chefCredentialsStep').fullname]",

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -235,6 +235,19 @@
             "defaultValue": "10.0.0.0/24"
         },
 
+        "existingVNetFromUI": {
+            "type": "string",
+            "metadata": {
+                "description": "The output from the UI does not provide a boolean value, only `new` or `existing`. This parameter will take this value and produce a boolean if it is set. This should not be used for manual template deployments."
+            },
+            "defaultValue": "",
+            "allowedValues": [
+                "",
+                "new",
+                "existing"
+            ]
+        },        
+
         "verifyURL": {
             "type": "string",
             "metadata": {
@@ -343,7 +356,7 @@
         },
 
         "network": {
-            "existing": "[parameters('existingVNet')]",
+            "existing": "[if(empty(parameters('existingVNetFromUI')), parameters('existingVNet'), if(equals(parameters('existingVNetFromUI'), 'new'), bool(0), bool(1)))]",
             "resourceGroup": "[parameters('customerResourceGroupName')]",
             "prefix": {
                 "vnet": "[parameters('vnetPrefix')]",

--- a/src/templates/app-service.json
+++ b/src/templates/app-service.json
@@ -63,7 +63,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "latest"
+                            "value": "~1"
                         }
                     ]
                 }

--- a/src/templates/virtual-network.json
+++ b/src/templates/virtual-network.json
@@ -76,6 +76,10 @@
       "subnetRef": {
         "value": "[concat(resourceId(variables('network').resourceGroup, 'Microsoft.Network/virtualNetworks', variables('name').vnet), '/subnets/', variables('name').subnet)]",
         "type": "string"
+      },
+      "existingVNet": {
+        "value": "[variables('network').existing]",
+        "type": "bool"
       }
     }
   }


### PR DESCRIPTION
Updated the template so that it passes the correct information to the underlying template to create a new VNet if selected.

New information text has been added about creating a new network and that it will not be manageable by the customer.

Added an advisory that if the customer is in a PAYG subscription they are not able to create a Free tier Log Analytics.

Converted British spelling of 'Organisation' to American 'Organization'.

/cc @trevorghess 