### PR TITLE
Deploy files from package rather than own blob storage

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -216,6 +216,7 @@ function patch(options, buildConfig) {
     }
 
     // Patch the mainTemplate so that it has the correct BaseURl if it has been specified in options
+    /*
     let mainTemplateFile = pathJoin(buildConfig[dirsKey][workingKey][productionKey], "mainTemplate.json");
     if (existsSync(mainTemplateFile)) {
         if (options.baseurl !== "") {
@@ -230,6 +231,7 @@ function patch(options, buildConfig) {
     } else {
         console.log("##vso[task.issue type=error]Unable to find main template: %s", mainTemplateFile);
     }
+    */
 
     // Patch the createUIDefinition.json file with the API key for the verifyurl
     let uiDefinitionFile = pathJoin(buildConfig[dirsKey][workingKey][productionKey], "createUiDefinition.json");
@@ -263,6 +265,7 @@ function createStaging(options, buildConfig) {
     copySync(buildConfig[dirsKey][workingKey][productionKey], buildConfig[dirsKey][workingKey][stagingKey]);
 
     // patch the mainTemplate with the staging URL
+    /*
     let mainTemplateFile = pathJoin(buildConfig[dirsKey][workingKey][stagingKey], "mainTemplate.json");
     if (existsSync(mainTemplateFile)) {
         if (options.url !== "") {
@@ -277,6 +280,7 @@ function createStaging(options, buildConfig) {
     } else {
         console.log("##vso[task.issue type=error]Unable to find main template: %s", mainTemplateFile);
     }
+    */
 }
 
 function packageFiles(options, buildConfig) {

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -215,24 +215,6 @@ function patch(options, buildConfig) {
         }
     }
 
-    // Patch the mainTemplate so that it has the correct BaseURl if it has been specified in options
-    /*
-    let mainTemplateFile = pathJoin(buildConfig[dirsKey][workingKey][productionKey], "mainTemplate.json");
-    if (existsSync(mainTemplateFile)) {
-        if (options.baseurl !== "") {
-            console.log("Patching main template: %s", mainTemplateFile);
-
-            let mainTemplate = JSON.parse(readFileSync(mainTemplateFile, "utf8"));
-
-            // patch the default value for the parameter
-            mainTemplate[parametersKey][baseUrlKey][defaultValueKey] = options.baseurl;
-            writeFileSync(mainTemplateFile, JSON.stringify(mainTemplate, null, 4), "utf8");
-        }
-    } else {
-        console.log("##vso[task.issue type=error]Unable to find main template: %s", mainTemplateFile);
-    }
-    */
-
     // Patch the createUIDefinition.json file with the API key for the verifyurl
     let uiDefinitionFile = pathJoin(buildConfig[dirsKey][workingKey][productionKey], "createUiDefinition.json");
     if (existsSync(uiDefinitionFile)) {
@@ -263,24 +245,6 @@ function createStaging(options, buildConfig) {
 
     // copy the contents of the production directory to staging
     copySync(buildConfig[dirsKey][workingKey][productionKey], buildConfig[dirsKey][workingKey][stagingKey]);
-
-    // patch the mainTemplate with the staging URL
-    /*
-    let mainTemplateFile = pathJoin(buildConfig[dirsKey][workingKey][stagingKey], "mainTemplate.json");
-    if (existsSync(mainTemplateFile)) {
-        if (options.url !== "") {
-            console.log("Patching main template: %s", mainTemplateFile);
-
-            let mainTemplate = JSON.parse(readFileSync(mainTemplateFile, "utf8"));
-
-            // patch the default value for the parameter
-            mainTemplate[parametersKey][baseUrlKey][defaultValueKey] = options.url;
-            writeFileSync(mainTemplateFile, JSON.stringify(mainTemplate, null, 4), "utf8");
-        }
-    } else {
-        console.log("##vso[task.issue type=error]Unable to find main template: %s", mainTemplateFile);
-    }
-    */
 }
 
 function packageFiles(options, buildConfig) {

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -222,7 +222,11 @@
 
         "baseUrl": {
             "type": "string",
-            "defaultValue": "https://chefarmstorage.blob.core.windows.net/ama"
+            "defaultValue": "https://chefarmstorage.blob.core.windows.net/ama",
+            "metadata": {
+                "description": "URL from which nested templates can be found",
+                "artifactsBaseUrl": ""
+            }
         },
 
         "azureStorageSASToken": {


### PR DESCRIPTION
Up and until now the templates that are pulled in are from our own blob storage that we upload during hte build. The problem with this is that when we run a nightly build or one from another branch the files get overwritten making it very brittle.

By modifying the `mainTemplate.json` file to include the `artifactsBaseUrl` in the metadata of the `baseUrl` parameter the deployment of the package means that the URL of where the files have been unpacked will be patched in, which is specific to the deployment.

The build process code that patches the template file with the `baseUrl` has been removed.

By doing this it is less brittle and we can enabled CI again.

Closes #25

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>