### PR TITLE
UI Updates

### DIFF
--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -11,7 +11,7 @@
                 "toolTip": "A prefix that should be applied to all resources that are created",
                 "constraints": {
                     "required": true,
-                    "regex": "^[a-z][a-z0-9]{1,4}$",
+                    "regex": "^[a-z0-9]{1,5}$",
                     "validationMessage": "This must be a lowercase aplhanumeric string and no more than 5 characters"
                 }
             }

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -78,8 +78,8 @@
                         "toolTip": "Username for the Chef and Automate servers",
                         "constraints": {
                             "required": true,
-                            "regex": "^[a-z0-9]+$",
-                            "validationMessage": "Only lower case alphanumeric characters are allowed."
+                            "regex": "^(?!admin)(^[a-z0-9]+)$",
+                            "validationMessage": "Only lower case alphanumeric characters are allowed. Username cannot be or start with 'admin'."
                         },
                         "visible": true
                     },

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -11,8 +11,8 @@
                 "toolTip": "A prefix that should be applied to all resources that are created",
                 "constraints": {
                     "required": true,
-                    "regex": "^[a-z0-9]{1,5}$",
-                    "validationMessage": "This must be a lowercase aplhanumeric string and no more than 5 characters"
+                    "regex": "^[a-z][a-z0-9]{1,4}$",
+                    "validationMessage": "The prefix must start with a letter, be alphanumeric and can be up to 5 characters long"
                 }
             }
         ],

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -178,14 +178,11 @@
                 },
                 "elements": [
                     {
-                        "name": "customerName",
-                        "type": "Microsoft.Common.TextBox",
-                        "label": "Customer Name",
-                        "toolTip": "Your name or company name. This should be the same as the name registered for the Automate License",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^[a-zA-Z0-9 ]+$",
-                            "validationMessage": "A company name or your name must be specified"
+                        "name": "information",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "If you already have an automate license select 'Yes' and then provide your license and the name it was registered with.<p />If you do not have an Automate License a trial one will be provided on deployment."
                         },
                         "visible": true
                     },
@@ -210,6 +207,18 @@
                       },
                       "visible": true
                     },
+                    {
+                        "name": "customerName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Customer Name",
+                        "toolTip": "Your name or company name. This should be the same as the name registered for the Automate License",
+                        "constraints": {
+                            "required": "[steps('automateLicenseStep').hasLicense]",
+                            "regex": "^[a-zA-Z0-9 ]+$",
+                            "validationMessage": "A company name or your name must be specified"
+                        },
+                        "visible": "[steps('automateLicenseStep').hasLicense]"
+                    },                    
                     {
                       "name": "license",
                       "type": "Microsoft.Common.TextBox",


### PR DESCRIPTION
Corrected some issues with the UI in the portal when CAMSA is deployed from the marketplace.

## Corrected validation and spelling on prefix validation

Checks that the first character is not a number which is not allowed when the DNS entries are created for the machines

<img width="609" alt="firefox_2019-07-18_15-20-34" src="https://user-images.githubusercontent.com/791658/61468982-54799500-a976-11e9-974d-a10748717297.png">

## Username for Chef / Automate user can be or start with `admin`

The validation has been updated so that the username cannot be or start with admin.

<img width="605" alt="firefox_2019-07-18_11-05-32" src="https://user-images.githubusercontent.com/791658/61469147-9a365d80-a976-11e9-99b3-973c042bb573.png">

## Name for Automate license is only required when providing own license

The template has always allowed people to get trial license, but the name was also required on the form. This is not the case now. The name is only requested if the customer provides their own license during deployment.

A trial license does need a name to get the license, but the name provided for the Chef / Automate user is used in this case.

<img width="606" alt="firefox_2019-07-18_11-06-19" src="https://user-images.githubusercontent.com/791658/61469294-d4076400-a976-11e9-96a1-a9ff2d92b748.png">

