### PR TITLE
Modified backup script

### DIFF
--- a/src/scripts/backup.sh
+++ b/src/scripts/backup.sh
@@ -36,6 +36,8 @@ WORKING_DIR="/tmp/backup"
 
 DRY_RUN=0
 
+removeBackupCmd=""
+
 # FUNCTIONS -------------------------------------------------------------------
 function urlencode() {
 	local LANG=C i c e=''
@@ -287,7 +289,15 @@ then
 
         # Read in the IDs and build up the removeBackupCmd
         ids=`cat backups.json | jq -r '[.result.backups[] | .id] | join(" ")'`
-        removeBackupCmd="chef-automate backup delete --yes ${ids} && rm backups.json"
+
+        # Only attempt to delete backups if there are some IDs
+        # If not then just remove the backups json file
+        if [ "X$ids" == "X" ]
+        then
+          removeBackupCmd="rm backups.json"
+        else
+          removeBackupCmd="chef-automate backup delete --yes ${ids} && rm backups.json"
+        fi
 
       ;;
 

--- a/src/scripts/backup.sh
+++ b/src/scripts/backup.sh
@@ -279,6 +279,16 @@ then
         # Determine the filename to be used as the blob name
         blob_name="automate_`basename $BACKUP_PATH`"
 
+        # Get a list of the backup IDs to remove
+        # and then build up the command that needs to be run at the end
+        # Get list of the backup ids into a json file
+        cmd="chef-automate backup list --result-json backups.json"
+        executeCmd "$cmd"
+
+        # Read in the IDs and build up the removeBackupCmd
+        ids=`cat backups.json | jq -r '[.result.backups[] | .id] | join(" ")'`
+        removeBackupCmd="chef-automate backup delete --yes ${ids} && rm backups.json"
+
       ;;
 
     chef)
@@ -294,6 +304,9 @@ then
 
         # Determine the filename to be used as the blob name
         blob_name="`basename $BACKUP_PATH`"
+
+        # Determine the command to remove the backup from disk
+        removeBackupCmd="rm -rf $BACKUP_PATH"
 
       ;;
 
@@ -390,10 +403,16 @@ curl -X "PUT" \
    -d "$body" \
    "https://${STORAGE_ACCOUNT}.blob.core.windows.net/${CONTAINER_NAME}/${blob_name}?comp=blocklist"
 
-# Finally remove the working directory
+# Remove the working directory
 log "Removing temporary working directory"
 rm -rf $WORKING_DIR
 
 # Remove the backup file to prevent the disk from filling up
-log "Removing local copy of backup archive file"
-rm -rf $BACKUP_PATH
+# This command is specific to the type of server that has been deployed
+# Automate has a built in command to delete backups which handles the ES snapshots too
+# For this reason the correct command is determined by the backup type
+if [ "X$removeBackupCmd" != "X" ]
+then
+  log "Removing local copy of backup archive file"
+  executeCmd "$removeBackupCmd"
+fi


### PR DESCRIPTION
To manage the backups on the Automate server correctly the `chef-automate backup` command is used.

This has to be passed the IDs of the backups that are to be deleted. This is extracted using `chef-automate backup list` and using `jq` the IDs of the backups are retrieved. The delete command is then built to be run at the end of the script.

By using this the ElasticSearch snapshots are managed as well.

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>