### PR TITLE
Corrected names of warnings to display correctly

### DIFF
--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -365,7 +365,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Warning",
-                                    "text": "If an SSL renewal is required, both the Automate and Chef services will be taken down to allow this. Renewal will occur within 30 days of expiry."
+                                    "text": "If an SSL renewal is required, Chef services will be taken down to allow this. Renewal will occur within 30 days of expiry."
                                 },
                                 "visible": true
                             },
@@ -554,7 +554,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Warning",
-                                    "text": "The Chef Server will be brought down during the backup so please set the backup to run at a time that has minimal impact."
+                                    "text": "Chef Services will be brought down during the backup so please set the backup to run at a time that has minimal impact."
                                 },
                                 "visible": true
                             },

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -361,7 +361,7 @@
                         "label": "SSL renewal",
                         "elements": [
                             {
-                                "name": "warning",
+                                "name": "warning_ssl",
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Warning",
@@ -550,7 +550,7 @@
                         "label": "Backup",
                         "elements": [
                             {
-                                "name": "warning",
+                                "name": "warning_backup",
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Warning",


### PR DESCRIPTION
The names of the warning boxes for the Backup and SSL Renewal cron schedule have been set differently so they are now displayed correctly.

![image](https://user-images.githubusercontent.com/791658/63754837-74717200-c8ad-11e9-969c-d3b503530219.png)

Fixes #53

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>