### PR TITLE
User is set as an admin on the Chef server

### DIFF
--- a/src/scripts/chef-server.sh
+++ b/src/scripts/chef-server.sh
@@ -489,6 +489,11 @@ do
               $CHEF_USER_NAME \
               $CHEF_ORGNAME)
         executeCmd "${cmd}"
+
+        # Ensure the the user is an admin of the chef server so that new users can be created
+        log "setting user as admin" 1
+        cmd=$(printf 'chef-server-ctl grant-server-admin-permissions %s' $CHEF_USER_NAME)
+        executeCmd "${cmd}"
       fi
 
       # Create a user that can be used to monitor the Chef server using the API


### PR DESCRIPTION
When the user is created on the Chef server it is now added as a member of the admins group so that new users can be created when required.

Fixes #52

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>