### PR TITLE
Log Analytics deployment Location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,6 @@ stages:
           = /parameters/chefUserEmailaddress/value => "inspec@example.com"
           = /parameters/chefOrg/value => "camsa"
           = /parameters/chefOrgDescription/value => "Chef Automate Managed Service Application"
-          = /parameters/logAnalyticsTier/value => "Free"
           = /parameters/debug/value => true
           = /parameters/autoDiscoverSASToken/value => true
           = /parameters/sshSourceAddresses/value => ["10.1.1.0/24"]

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -233,109 +233,7 @@
                       "visible": "[steps('automateLicenseStep').hasLicense]"
                     }
                 ]
-            },
-
-            {
-                "name": "logAnalyticsStep",
-                "label": "Log Analytics",
-                "bladeTitle": "Log Analytics Tier",
-                "subLabel": {
-                    "preValidation": "Please select the tier you want to use for your Log Analytics workspace",
-                    "postValidation": "Log Analytics tier has been specified"
-                },
-                "elements": [
-                    {
-                        "name": "warning",
-                        "type": "Microsoft.Common.InfoBox",
-                        "options": {
-                            "icon": "Info",
-                            "text": "If you are on a Pay As You Go Azure Subscription you cannot use the Free Log Analytics tier."
-                        },
-                        "visible": true
-                    },
-                    {
-                        "name": "tier",
-                        "type": "Microsoft.Common.DropDown",
-                        "label": "Tier",
-                        "toolTip": "Please select the appropriate service tier",
-                        "defaultValue": "Free",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "Free",
-                                    "value": "Free"
-                                },
-                                {
-                                    "label": "PerNode",
-                                    "value": "PerNode"
-                                },
-                                {
-                                    "label": "PerGB2018",
-                                    "value": "PerGB2018"
-                                }
-                            ]
-                        },
-                        "visible": true
-                    },
-                    {
-                        "name": "location",
-                        "type": "Microsoft.Common.DropDown",
-                        "label": "Location",
-                        "toolTip": "Location that the Log Analytcis should be deployed into",
-                        "defaultValue": "eastus",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "Australia Central",
-                                    "value": "australiacentral"
-                                },
-                                {
-                                    "label": "Australia Central 2",
-                                    "value": "australiacentral2"
-                                },
-                                {
-                                    "label": "Australia South East",
-                                    "value": "australiasoutheast"
-                                },
-                                {
-                                    "label": "Canada Central",
-                                    "value": "canadacentral"
-                                },
-                                {
-                                    "label": "Central India",
-                                    "value": "centralindia"
-                                },
-                                {
-                                    "label": "East US",
-                                    "value": "eastus"
-                                },
-                                {
-                                    "label": "Japan East",
-                                    "value": "japaneast"
-                                },
-                                {
-                                    "label": "South East Asia",
-                                    "value": "southeastasia"
-                                },
-                                {
-                                    "label": "UK South",
-                                    "value": "uksouth"
-                                },
-                                {
-                                    "label": "West Central US",
-                                    "value": "westcentralus"
-                                },
-                                {
-                                    "label": "West Europe",
-                                    "value": "westeurope"
-                                }                                
-                            ],
-                            "required": true 
-                        },
-                        "visible": true
-                    }
-                ]
-            },            
+            },  
 
             {
                 "name": "advancedSettings",
@@ -797,8 +695,6 @@
             "chefOrgDescription": "[steps('chefCredentialsStep').orgdescription]",
             "automateLicense": "[steps('automateLicenseStep').license]",
             "customerName": "[steps('automateLicenseStep').customerName]",
-            "logAnalyticsTier": "[steps('logAnalyticsStep').tier]",
-            "logAnalyticsLocation": "[steps('logAnalyticsStep').location]",
             "backupHour": "[steps('advancedSettings').backupCronSection.hour]",
             "backupMinute": "[steps('advancedSettings').backupCronSection.minute]",
             "location": "[location()]",

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -210,16 +210,6 @@
             }
         },
 
-        "logAnalyticsTier": {
-            "type": "string",
-            "defaultValue": "Free"
-        },
-
-        "logAnalyticsLocation": {
-            "type": "string",
-            "defaultValue": "eastus"
-        },
-
         "baseUrl": {
             "type": "string",
             "defaultValue": "https://chefarmstorage.blob.core.windows.net/ama",
@@ -401,7 +391,6 @@
         "baseUrl": "[if(not(empty(parameters('baseUrl'))), if(endsWith(parameters('baseUrl'), '/'), parameters('baseUrl'), concat(parameters('baseUrl'), '/')), if(contains(deployment().properties, 'templateLink'), uri(deployment().properties.templateLink.uri, '.'), ''))]",
 
         "location": "[parameters('location')]",
-        "logAnalyticsLocation": "[if(empty(parameters('logAnalyticsLocation')), variables('location'), parameters('logAnalyticsLocation'))]",
 
         "name": {
             "storageAccount": "[variables('unique')]",
@@ -563,10 +552,6 @@
         "automate": {
             "enabled": "[parameters('automateEnabled')]",
             "license": "[parameters('automateLicense')]"
-        },
-
-        "la": {
-            "sku": "[parameters('logAnalyticsTier')]"
         },
 
         "tags": {
@@ -888,11 +873,8 @@
                     "workspaceName": {
                         "value": "[variables('name').la]"
                     },
-                    "sku": {
-                        "value": "[variables('la').sku]"
-                    },
                     "location": {
-                        "value": "[variables('logAnalyticsLocation')]"
+                        "value": "[variables('location')]"
                     },
                     "logAnalyticsEnabled": {
                         "value": "[variables('enabled').logAnalytics]"

--- a/src/templates/log-analytics.json
+++ b/src/templates/log-analytics.json
@@ -8,9 +8,6 @@
                 "description": "The name of the workspace"
             }
         },
-        "sku": {
-            "type": "String"
-        },
         "location": {
             "defaultValue": "[resourceGroup().location]",
             "type": "String"
@@ -28,11 +25,10 @@
             "workspace": "[parameters('workspaceName')]"
         },
         "la": {
-            "sku": "[parameters('sku')]",
-            "retention": "[if(equals(toLower(parameters('sku')), 'free'), 7, 30)]"
+            "retention": "30"
         },
         "apiVersions": {
-            "workspace": "2015-03-20",
+            "workspace": "2015-11-01-preview",
             "dataSources": "2015-11-01-preview"
         },
         "tags": "[parameters('tags')]",
@@ -49,9 +45,6 @@
             "location": "[variables('location')]",
             "tags": "[variables('tags')]",
             "properties": {
-                "sku": {
-                    "name": "[variables('la').sku]"
-                },
                 "retentionInDays": "[variables('la').retention]"
             },
             "resources": [

--- a/src/templates/script-extension.json
+++ b/src/templates/script-extension.json
@@ -27,7 +27,7 @@
         },
 
         "scriptArguments": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
                 "description": "Arguments that should be passed to the script"
             },
@@ -35,7 +35,7 @@
         },
 
         "arguments": {
-            "type": "object",
+            "type": "secureObject",
             "defaultValue": {}
         },
 

--- a/test/integration/build/parameters.json
+++ b/test/integration/build/parameters.json
@@ -32,9 +32,6 @@
       "automateLicense": {
         "value": ""
       },
-      "logAnalyticsTier": {
-        "value": ""
-      },
       "autoDiscoverSASToken": {
         "value": false
       },


### PR DESCRIPTION
The Log Analytics deployment location now follows the main deployment location, there is no choice about where it is deployed.

Additionally the tier that is deployed is no longer an option and has been removed from the template as well as the `createUIDefinition.json` file. The tier will automatically be set to "Per GB (2018)" by Azure.

The arguments that are passed to the script extension for the Automate and Chef servers are now set as secure and will not be seen in plain text in the Input to the deployment template.